### PR TITLE
Fix Mobile `Email` Field in Contact Form

### DIFF
--- a/components/Contact/ContactForm.tsx
+++ b/components/Contact/ContactForm.tsx
@@ -124,7 +124,7 @@ export function ContactForm() {
                   </div>
                   <input
                     id="email"
-                    type="tel"
+                    type="email"
                     className="form-input w-full"
                     placeholder="yourname@example.com"
                     value={email}


### PR DESCRIPTION
## Description

This changes the contact form use `<input type="email">` for mobile keyboard rendering.